### PR TITLE
Handle null user id on withdrawal confirmation

### DIFF
--- a/requisi.html
+++ b/requisi.html
@@ -388,7 +388,7 @@
 
         // Função para verificar se o usuário é admin
         function isUserAdmin() {
-            const userData = JSON.parse(localStorage.getItem('userData') || '{}');
+            const userData = JSON.parse(sessionStorage.getItem('currentUser') || '{}');
             return userData.userType === 'admin';
         }
 
@@ -409,7 +409,7 @@
 
         // Função para carregar dados do usuário logado
         function carregarDadosUsuario() {
-            const userData = JSON.parse(localStorage.getItem('userData') || '{}');
+            const userData = JSON.parse(sessionStorage.getItem('currentUser') || '{}');
             
             if (!userData.id) {
                 document.getElementById('accessDenied').classList.remove('hidden');

--- a/requisi.js
+++ b/requisi.js
@@ -1776,7 +1776,14 @@ async function confirmarRetirada(retiradaId) {
     }
     
     try {
-        const usuario = JSON.parse(localStorage.getItem('userData'));
+        const usuario = JSON.parse(sessionStorage.getItem('currentUser') || '{}');
+        
+        // Verificar se o usuário está logado
+        if (!usuario || !usuario.id) {
+            mostrarAlerta('Erro: Usuário não está logado. Faça login novamente.', 'error');
+            window.location.href = 'login.html';
+            return;
+        }
         
         const response = await fetch(`/api/retiradas-pendentes/${retiradaId}/confirmar`, {
             method: 'POST',
@@ -1850,7 +1857,14 @@ function fecharModalCancelamento() {
 async function confirmarCancelamento(retiradaId) {
     try {
         const motivo = document.getElementById('motivoCancelamento').value.trim();
-        const usuario = JSON.parse(localStorage.getItem('userData'));
+        const usuario = JSON.parse(sessionStorage.getItem('currentUser') || '{}');
+        
+        // Verificar se o usuário está logado
+        if (!usuario || !usuario.id) {
+            mostrarAlerta('Erro: Usuário não está logado. Faça login novamente.', 'error');
+            window.location.href = 'login.html';
+            return;
+        }
         
         const response = await fetch(`/api/retiradas-pendentes/${retiradaId}/cancelar`, {
             method: 'POST',


### PR DESCRIPTION
Fixes "can't access property 'id', usuario is null" error by standardizing user data retrieval to `sessionStorage`.

The `confirmarRetirada` and `confirmarCancelamento` functions, along with some auxiliary functions, were incorrectly attempting to retrieve user data from `localStorage.getItem('userData')`, while the application consistently stores user information in `sessionStorage.getItem('currentUser')`. This led to a null `usuario` object and subsequent errors when accessing its properties. The fix ensures all relevant functions use the correct `sessionStorage` key and adds null checks for robustness.

---
<a href="https://cursor.com/background-agent?bcId=bc-f0a5cbfd-a87c-4af9-a23d-c1f0237c14ed">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f0a5cbfd-a87c-4af9-a23d-c1f0237c14ed">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

